### PR TITLE
Bubble up exceptions

### DIFF
--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -27,7 +27,7 @@ module Rack
             env['jwt.header']  = decoded_token.last
             env['jwt.payload'] = decoded_token.first
             @app.call(env)
-          rescue
+          rescue ::JWT::DecodeError
             return_error('Invalid JWT token')
           end
         else

--- a/lib/rack/jwt/token.rb
+++ b/lib/rack/jwt/token.rb
@@ -7,9 +7,6 @@ module Rack
 
       def self.decode(token, secret)
         ::JWT.decode(token, secret)
-      rescue
-        # It will raise an error if it is not a valid token due to any reason
-        nil
       end
     end
   end


### PR DESCRIPTION
Instead of returning "Invalid JWT token" when an error occurs

Not sure this is the intended behavior but we were having an issue with our app that was unrelated to authentication and since the middleware currently `rescue`s from all exceptions it took us a long time to track down what was going on.

Please LMK if you think this could be handled in a different way! :beers: 