### PR TITLE
Updated jwt gem and allow jwt options hash to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Or install it yourself as:
 ### Sinatra
 
 ```
-use Rack::JWT::Auth secret: 'you_secret_token_goes_here', verify: true, options: {}, exclude: ['/api/docs']
+use Rack::JWT::Auth, secret: 'you_secret_token_goes_here', verify: true, options: {}, exclude: ['/api/docs']
 ```
 
 ### Cuba
 
 ```
-Cuba.use Rack::JWT::Auth secret: 'you_secret_token_goes_here', verify: true, options: {}, exclude: ['/api/docs']
+Cuba.use Rack::JWT::Auth, secret: 'you_secret_token_goes_here', verify: true, options: {}, exclude: ['/api/docs']
 ```
 
 ### Rails

--- a/README.md
+++ b/README.md
@@ -24,16 +24,30 @@ Or install it yourself as:
 
 ## Usage
 
-### sinatra
+`Rack::JWT::Auth` accepts several configuration options:
+
+* `secret` : required : String : A cryptographically secure String that serves as the HMAC SHA-256 secret for the JSON Web Token.
+* `verify` : optional : Boolean : Determines whether JWT will verify tokens when decoded. Default is `true`.
+* `options` : optional : Hash : A hash of options that are passed through to JWT to configure supported claims. See [the ruby-jwt docs](https://github.com/progrium/ruby-jwt#support-for-reserved-claim-names) for the available options. By default only expiration (exp) and Not Before (nbf) claims are verified.
+* `exclude` : optional : Array : An Array of path strings representing paths that should not check for JWT authentication tokens before allowing access.
+
+
+### Sinatra
 
 ```
-use Rack::JWT::Auth secret: 'you_secret_token_goes_here', exclude: ['/api/docs']
+use Rack::JWT::Auth secret: 'you_secret_token_goes_here', verify: true, options: {}, exclude: ['/api/docs']
+```
+
+### Cuba
+
+```
+Cuba.use Rack::JWT::Auth secret: 'you_secret_token_goes_here', verify: true, options: {}, exclude: ['/api/docs']
 ```
 
 ### Rails
 
 ```
-Rails.application.config.middleware.use, Rack::JWT::Auth, secret: Rails.application.secrets.secret_key_base, exclude: ['/api/docs']
+Rails.application.config.middleware.use, Rack::JWT::Auth, secret: Rails.application.secrets.secret_key_base, verify: true, options: {}, exclude: ['/api/docs']
 ```
 
 ## Generating tokens

--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -5,7 +5,9 @@ module Rack
     class Auth
       def initialize(app, opts = {})
         @app      = app
-        @secret   = opts.fetch(:secret)
+        @jwt_secret   = opts.fetch(:secret)
+        @jwt_verify   = opts.fetch(:verify, true)
+        @jwt_options  = opts.fetch(:options, {})
         @exclude  = opts.fetch(:exclude, [])
       end
 
@@ -23,7 +25,7 @@ module Rack
         if valid_header?(env)
           begin
             token = env['HTTP_AUTHORIZATION'].split(' ')[-1]
-            decoded_token = Token.decode(token, @secret)
+            decoded_token = Token.decode(token, @jwt_secret, @jwt_verify, @jwt_options)
             env['jwt.header']  = decoded_token.last
             env['jwt.payload'] = decoded_token.first
             @app.call(env)

--- a/lib/rack/jwt/token.rb
+++ b/lib/rack/jwt/token.rb
@@ -1,12 +1,14 @@
 module Rack
   module JWT
     class Token
+      # TODO : Support all algorithms, not just default 'HS256'
+      # https://github.com/progrium/ruby-jwt#algorithms-and-usage
       def self.encode(payload, secret)
-        ::JWT.encode(payload, secret)
+        ::JWT.encode(payload, secret, 'HS256')
       end
 
-      def self.decode(token, secret)
-        ::JWT.decode(token, secret)
+      def self.decode(token, secret, verify, options)
+        ::JWT.decode(token, secret, verify, options)
       rescue
         # It will raise an error if it is not a valid token due to any reason
         nil

--- a/lib/rack/jwt/version.rb
+++ b/lib/rack/jwt/version.rb
@@ -1,5 +1,5 @@
 module Rack
-  module Jwt
+  module JWT
     VERSION = "0.1.1"
   end
 end

--- a/rack-jwt.gemspec
+++ b/rack-jwt.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec',     '~> 3.2.0'
 
   spec.add_runtime_dependency 'rack', '>= 1.6.0'
-  spec.add_runtime_dependency 'jwt', '~> 1.2.1'
+  spec.add_runtime_dependency 'jwt', '~> 1.5.0'
 end

--- a/rack-jwt.gemspec
+++ b/rack-jwt.gemspec
@@ -5,7 +5,7 @@ require 'rack/jwt/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "rack-jwt"
-  spec.version       = Rack::Jwt::VERSION
+  spec.version       = Rack::JWT::VERSION
   spec.authors       = ["Mr. Eigenbart"]
   spec.email         = ["eigenbart@gmail.com"]
   spec.summary       = %q{Rack middleware that provides authentication based on JSON Web Tokens.}

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 describe Rack::JWT::Auth do
   include Rack::Test::Methods
 
-  let(:issuer) { Rack::JWT::Token }
-  let(:secret) { 'foo' }
-  let(:body)   {{ 'foo' => 'bar' }}
+  let(:issuer)  { Rack::JWT::Token }
+  let(:secret)  { 'foo' }
+  let(:verify)  { true }
+  let(:options) { {} }
+  let(:body)    {{ 'foo' => 'bar' }}
 
   let(:app) do
     main_app = lambda { |env| [200, env, [body.to_json]] }
@@ -38,7 +40,7 @@ describe Rack::JWT::Auth do
     end
   end
 
-  context 'when authorzation header does not contain the schema' do
+  context 'when authorization header does not contain the schema' do
     let(:token) { issuer.encode({ iss: 1 }, secret) }
     let(:headers) {{ 'HTTP_AUTHORIZATION' => token }}
 
@@ -83,6 +85,21 @@ describe Rack::JWT::Auth do
     end
   end
 
+  context 'when token signature is invalid and JWT verify option is false' do
+    let(:app) do
+      main_app = lambda { |env| [200, env, [body.to_json]] }
+      Rack::JWT::Auth.new(main_app, { secret: secret, verify: false })
+    end
+    let(:token) { issuer.encode({ iss: 1 }, 'invalid secret') }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "Bearer #{token}" }}
+
+    subject { JSON.parse(last_response.body) }
+
+    it 'returns 200 status code' do
+      expect(last_response.status).to eq(200)
+    end
+  end
+
   context 'when token is valid' do
     let(:token) { issuer.encode({ iss: 1 }, secret) }
     let(:headers) {{ 'HTTP_AUTHORIZATION' => "Bearer #{token}" }}
@@ -108,4 +125,87 @@ describe Rack::JWT::Auth do
       expect(header['typ']).to eq('JWT')
     end
   end
+
+  # Test the pass-through of the options Hash to JWT using Issued At (iat) claim to test..
+  ###
+
+  context 'when token is valid and an invalid Issued At (iat) claim is provided JWT should ignore bad iat by default' do
+    let(:token) { issuer.encode({ iss: 1, iat: Time.now.to_i + 1000000 }, secret) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "Bearer #{token}" }}
+
+    subject { JSON.parse(last_response.body) }
+
+    it 'returns 200 status code' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'process the request' do
+      expect(subject).to eq(body)
+    end
+
+    it 'adds the token payload to the request' do
+      payload = last_response.header['jwt.payload']
+      expect(payload['iss']).to eq(1)
+    end
+
+    it 'adds the token header to the request' do
+      header = last_response.header['jwt.header']
+      expect(header['alg']).to eq('HS256')
+      expect(header['typ']).to eq('JWT')
+    end
+  end
+
+  context 'when token is valid and an invalid Issued At (iat) claim is provided and iat verification option is enabled' do
+    # The token was issued at an insane time in the future.
+    let(:iat) { Time.now.to_i + 1000000 }
+    let(:app) do
+      main_app = lambda { |env| [200, env, [body.to_json]] }
+      Rack::JWT::Auth.new(main_app, { secret: secret, options: { :verify_iat => true } })
+    end
+    let(:token) { issuer.encode({ iss: 1, iat: iat }, secret) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "Bearer #{token}" }}
+
+    subject { JSON.parse(last_response.body) }
+
+    it 'returns 401 status code' do
+      expect(last_response.status).to eq(401)
+    end
+
+    it 'returns an error message' do
+      expect(subject['error']).to eq('Invalid JWT token')
+    end
+  end
+
+  context 'when token is valid and a valid Issued At (iat) claim is provided and iat verification option is enabled' do
+    # The token was issued at a sane Time.now
+    let(:iat) { Time.now.to_i }
+    let(:app) do
+      main_app = lambda { |env| [200, env, [body.to_json]] }
+      Rack::JWT::Auth.new(main_app, { secret: secret, options: { :verify_iat => true } })
+    end
+    let(:token) { issuer.encode({ iss: 1, iat: iat }, secret) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "Bearer #{token}" }}
+
+    subject { JSON.parse(last_response.body) }
+
+    it 'returns 200 status code' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'process the request' do
+      expect(subject).to eq(body)
+    end
+
+    it 'adds the token payload to the request' do
+      payload = last_response.header['jwt.payload']
+      expect(payload['iss']).to eq(1)
+    end
+
+    it 'adds the token header to the request' do
+      header = last_response.header['jwt.header']
+      expect(header['alg']).to eq('HS256')
+      expect(header['typ']).to eq('JWT')
+    end
+  end
+
 end


### PR DESCRIPTION
Here is a group of commits to enhance the tool and clean up a couple of issues.

The main things addressed are:

* upgrade to security and bugfix upgrade of JWT gem
* allow passing through the options hash that the JWT gem requires in order to verify most claims.

I also pulled in the other pull request that was pending into this group of commits so you only need to do one merge to get both pull requests.

Tests have been added for all changes.

Cheers,

Glenn