### PR TITLE
Allow a proc as a secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ gem install rack-jwt
 
 `Rack::JWT::Auth` accepts several configuration options. All options are passed in a single Ruby Hash:
 
-* `secret` : required : `String` || `OpenSSL::PKey::RSA` || `OpenSSL::PKey::EC` : A cryptographically secure String (for HMAC algorithms) or a public key object of an appropriate type for public key algorithms. Set to `nil` if you are using the `'none'` algorithm.
+* `secret` : required : `String` || `OpenSSL::PKey::RSA` || `OpenSSL::PKey::EC` || `Proc.new { 'secret' }`: A cryptographically secure String (for HMAC algorithms) or a public key object of an appropriate type for public key algorithms. Set to `nil` if you are using the `'none'` algorithm.
 
 * `verify` : optional : Boolean : Determines whether JWT will verify tokens keys for mismatch key types when decoded. Default is `true`. Set to `false` if you are using the `'none'` algorithm.
 
@@ -65,6 +65,7 @@ Rails.application.config.middleware.use, Rack::JWT::Auth, my_args
 ```
 
 ## Generating tokens
+
 You can generate JSON Web Tokens for your users using the
 `Rack::JWT::Token#encode` method which takes `payload`,
 `secret`, and `algorithm` params.
@@ -102,6 +103,20 @@ my_payload = {
 alg = 'HS256'
 
 Rack::JWT::Token.encode(my_payload, secret, alg)
+```
+
+## Using a proc as secret
+
+To solve the issue where individual user instances holds the secret, and not the application/backend a proc is available. This can be used something like this:
+
+```ruby
+args = {
+  secret: Proc.new do |token|
+    # Deserialize token
+    # Find user
+    user.secret
+  end
+}
 ```
 
 ## Contributing

--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -67,8 +67,13 @@ module Rack
 
         begin
           # If the secret is a proc evaluate it with the deserialized payload as a block
-          deserialized_payload = JSON.parse(Base64.decode64(token.split('.')[1]))
-          @secret = @secret.call(deserialized_payload) if @secret.respond_to?(:call)
+          # Otherwise just return the @secret as-is
+          secret = if @secret.respond_to?(:call)
+            deserialized_payload = JSON.parse(Base64.decode64(token.split('.')[1]))
+            @secret.call(deserialized_payload)
+          else
+            @secret
+          end
 
           decoded_token = Token.decode(token, @secret, @verify, @options)
           env['jwt.payload'] = decoded_token.first

--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -66,6 +66,10 @@ module Rack
         token = BEARER_TOKEN_REGEX.match(env['HTTP_AUTHORIZATION'])[1]
 
         begin
+          # If the secret is a proc evaluate it with the deserialized payload as a block
+          deserialized_payload = JSON.parse(Base64.decode64(token.split('.')[1]))
+          @secret = @secret.call(deserialized_payload) if @secret.respond_to?(:call)
+
           decoded_token = Token.decode(token, @secret, @verify, @options)
           env['jwt.payload'] = decoded_token.first
           env['jwt.header'] = decoded_token.last

--- a/lib/rack/jwt/auth.rb
+++ b/lib/rack/jwt/auth.rb
@@ -97,7 +97,8 @@ module Rack
         unless @secret.nil? ||
                @secret.is_a?(String) ||
                @secret.is_a?(OpenSSL::PKey::RSA) ||
-               @secret.is_a?(OpenSSL::PKey::EC)
+               @secret.is_a?(OpenSSL::PKey::EC) ||
+               @secret.is_a?(Proc)
           raise ArgumentError, 'secret argument must be a valid type'
         end
       end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -23,6 +23,13 @@ describe Rack::JWT::Auth do
         end
       end
 
+      describe 'with secret: Proc.new {} arg provided' do
+        let(:app) { Rack::JWT::Auth.new(inner_app, secret: Proc.new { |token| 'helo' }) }
+        it 'is allowed' do
+          expect(app.secret).to be_a Proc
+        end
+      end
+
       describe 'with no secret: arg provided' do
         it 'raises ArgumentError' do
           expect { Rack::JWT::Auth.new(inner_app, {}) }.to raise_error(ArgumentError)


### PR DESCRIPTION
Allowing a proc as a secret till allow the application implementing the JWT middleware to use a secret depending on the content of the payload. 

So if the payload is something like `{ 'user_id': 1 }`, then the secret used to sign the request can be individually assigned. This means that each user's ability to sign requests can be controlled in finer detail. 
