### PR TITLE
Fix syntax typo in example Rails config code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Cuba.use Rack::JWT::Auth, my_args
 ### Rails
 
 ```ruby
-Rails.application.config.middleware.use, Rack::JWT::Auth, my_args
+Rails.application.config.middleware.use Rack::JWT::Auth, my_args
 ```
 
 ## Generating tokens


### PR DESCRIPTION
There is a comma in there that would cause a syntax error